### PR TITLE
Allow dispatching of already dispatched subjects

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,7 +98,8 @@ async function dispatch(worshipAdministrativeUnit) {
     const subject = await getRelatedSubjectsForWorshipAdministrativeUnit(
       worshipAdministrativeUnit,
       config.type,
-      config.pathToWorshipAdminUnit
+      config.pathToWorshipAdminUnit,
+      destinationGraphs
     );
     subjects.push(...subject);
   }

--- a/app.js
+++ b/app.js
@@ -93,18 +93,20 @@ async function processSubject(subject) {
 
 async function dispatch(worshipAdministrativeUnit) {
   const destinationGraphs = await getDestinationGraphs(worshipAdministrativeUnit);
-  let subjects = [worshipAdministrativeUnit];
-  for (const config of exportConfig) {
-    const subject = await getRelatedSubjectsForWorshipAdministrativeUnit(
-      worshipAdministrativeUnit,
-      config.type,
-      config.pathToWorshipAdminUnit,
-      destinationGraphs
-    );
-    subjects.push(...subject);
-  }
+  if (destinationGraphs.length) {
+    let subjects = [worshipAdministrativeUnit];
+    for (const config of exportConfig) {
+      const subject = await getRelatedSubjectsForWorshipAdministrativeUnit(
+        worshipAdministrativeUnit,
+        config.type,
+        config.pathToWorshipAdminUnit,
+        destinationGraphs
+      );
+      subjects.push(...subject);
+    }
 
-  for(const subject of subjects) {
-    await copySubjectDataToDestinationGraphs(subject, destinationGraphs);
+    for(const subject of subjects) {
+      await copySubjectDataToDestinationGraphs(subject, destinationGraphs);
+    }
   }
 }

--- a/util/queries.js
+++ b/util/queries.js
@@ -12,22 +12,24 @@ export async function getRelatedSubjectsForWorshipAdministrativeUnit(
   pathToWorshipAdminUnit,
   destinationGraphs
 ) {
-  const formattedDestinationGraphs = destinationGraphs.map(g => sparqlEscapeUri(g)).join(',')
-
   const queryStr = `
-    SELECT DISTINCT ?subject WHERE {
+    SELECT DISTINCT ?g ?subject WHERE {
       BIND(${sparqlEscapeUri(worshipAdministrativeUnit)} as ?worshipAdministrativeUnit)
       ?subject a ${sparqlEscapeUri(subjectType)}.
+
       GRAPH ?g {
         ?subject ?p ?o .
       }
-      FILTER ( ?g NOT IN ( ${formattedDestinationGraphs} ) )
       ${pathToWorshipAdminUnit}
     }
   `;
 
   const result = await query(queryStr);
-  return result.results.bindings.map(r => r.subject.value);
+  return result.results.bindings
+    .filter(r => {
+      return destinationGraphs.find(g => g != r.g.value);
+    })
+    .map(r => r.subject.value);
 }
 
 export async function getTypesForSubject(subject) {

--- a/util/queries.js
+++ b/util/queries.js
@@ -9,15 +9,19 @@ const CREATOR = 'http://lblod.data.gift/services/worship-positions-graph-dispatc
 export async function getRelatedSubjectsForWorshipAdministrativeUnit(
   worshipAdministrativeUnit,
   subjectType,
-  pathToWorshipAdminUnit
+  pathToWorshipAdminUnit,
+  destinationGraphs
 ) {
+  const formattedDestinationGraphs = destinationGraphs.map(g => sparqlEscapeUri(g)).join(',')
+
   const queryStr = `
     SELECT DISTINCT ?subject WHERE {
       BIND(${sparqlEscapeUri(worshipAdministrativeUnit)} as ?worshipAdministrativeUnit)
       ?subject a ${sparqlEscapeUri(subjectType)}.
-      GRAPH ${sparqlEscapeUri(DISPATCH_SOURCE_GRAPH)} {
+      GRAPH ?g {
         ?subject ?p ?o .
       }
+      FILTER ( ?g NOT IN ( ${formattedDestinationGraphs} ) )
       ${pathToWorshipAdminUnit}
     }
   `;
@@ -97,9 +101,7 @@ export async function copySubjectDataToDestinationGraphs(subject, destinationGra
     }
     WHERE {
       BIND(${sparqlEscapeUri(subject)} as ?s)
-      GRAPH ${sparqlEscapeUri(DISPATCH_SOURCE_GRAPH)} {
-        ?s ?p ?o.
-      }
+      ?s ?p ?o.
     }
   `;
   await update(queryStr);

--- a/util/queries.js
+++ b/util/queries.js
@@ -13,11 +13,11 @@ export async function getRelatedSubjectsForWorshipAdministrativeUnit(
   destinationGraphs
 ) {
   const queryStr = `
-    SELECT DISTINCT ?g ?subject WHERE {
+    SELECT DISTINCT ?graph ?subject WHERE {
       BIND(${sparqlEscapeUri(worshipAdministrativeUnit)} as ?worshipAdministrativeUnit)
       ?subject a ${sparqlEscapeUri(subjectType)}.
 
-      GRAPH ?g {
+      GRAPH ?graph {
         ?subject ?p ?o .
       }
       ${pathToWorshipAdminUnit}
@@ -25,11 +25,16 @@ export async function getRelatedSubjectsForWorshipAdministrativeUnit(
   `;
 
   const result = await query(queryStr);
-  return result.results.bindings
+
+  // If the subject needs to go in a destination graph that is not in the list of graphs
+  // the subject already is (?g), we keep the subject to be propagated
+  const subjects = result.results.bindings
     .filter(r => {
-      return destinationGraphs.find(g => g != r.g.value);
+      return destinationGraphs.find(destinationGraphs => destinationGraphs != r.graph.value);
     })
     .map(r => r.subject.value);
+
+  return [ ...new Set(subjects)];
 }
 
 export async function getTypesForSubject(subject) {


### PR DESCRIPTION
Persons could be shared across multiple organizations.

With the previous implementation, if person A gets dispatched with position 1 in a first iteration and is then linked to position 2 later on, it will not be re-dispatched to the graphs of position 2 because the person is not in the tmp dispatch graph anymore.

This new implementation allows to dispatch subjects that are in graphs that are not the tmp dispatch graph.