### PR TITLE
Adjust logic to new consumer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-javascript-template:1.7.0
+FROM semtech/mu-javascript-template:1.8.0
 LABEL maintainer=info@redpencil
 ENV SUDO_QUERY_RETRY="true"
 ENV SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES="404,500,503"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ export default [
 ]
 ```
 
+## Environment variables
+
+The following environment variables can be configured:
+
+- `LANDING_ZONE_GRAPHS`: The graphs where the consumers first put the consumed data, separated by a ",". Defaults to 'http://mu.semte.ch/graphs/landing-zone/worship-services-sensitive,http://mu.semte.ch/graphs/landing-zone/worship-posts'
+- `DISPATCH_SOURCE_GRAPH`: The graphs from which we want to dispatch the triples. Defaults to 'http://mu.semte.ch/graphs/ingest'
+
 ## Initial dispatch
 
 When starting the service, before dispatching the incoming deltas to the proper graphs, the service will check if an initial dispatching needs to happen. For this, it will check if the two related consumers (`worship-services-sensitive-consumer` and `worship-posts-consumer`) of the related application [app-worship-organizations](https://github.com/lblod/app-worship-organizations) have finished putting all ingested data into the ingest graph.

--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ import {
   getTypesForSubject,
   getWorshipAdministrativeUnitForSubject,
   getDestinationGraphs,
-  copySubjectDataToDestinationGraphs,
+  moveSubjectDataToDestinationGraphs,
   getRelatedSubjectsForWorshipAdministrativeUnit,
   isSubjectPublicAfterAdditionalFilters,
   insertRepresentativeOrganExtraTriples,
@@ -128,7 +128,7 @@ async function processOrgSubject(subject, matchingOrgConfigs) {
 }
 
 async function dispatchToPublicGraph(subject, config) {
-  await copySubjectDataToDestinationGraphs(subject, [PUBLIC_GRAPH]);
+  await moveSubjectDataToDestinationGraphs(subject, [PUBLIC_GRAPH]);
 
   // We need to see if some subjects need to be re-evaluated. In some cases, the previously dispatched data
   // can fix broken paths to dispatch other data types
@@ -178,7 +178,7 @@ async function dispatchToOrgGraphs(worshipAdministrativeUnit) {
     }
 
     for(const subject of subjects) {
-      await copySubjectDataToDestinationGraphs(subject, destinationGraphs);
+      await moveSubjectDataToDestinationGraphs(subject, destinationGraphs);
     }
   }
 }

--- a/config.js
+++ b/config.js
@@ -1,3 +1,4 @@
+export const LANDING_ZONE_GRAPHS = process.env.LANDING_ZONE_GRAPHS || 'http://mu.semte.ch/graphs/landing-zone/worship-services-sensitive,http://mu.semte.ch/graphs/landing-zone/worship-posts';
 export const DISPATCH_SOURCE_GRAPH = process.env.DISPATCH_SOURCE_GRAPH || 'http://mu.semte.ch/graphs/ingest';
 export const INITIAL_DISPATCH_ENDPOINT = process.env.DIRECT_DATABASE_ENDPOINT || process.env.MU_SPARQL_ENDPOINT
 export const PUBLIC_GRAPH = 'http://mu.semte.ch/graphs/public';

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -2,6 +2,7 @@ import { sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime, uuid } from 
 import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
 import { parseResult } from './utils';
 import {
+  LANDING_ZONE_GRAPHS,
   DISPATCH_SOURCE_GRAPH,
   CREATOR,
   PUBLIC_GRAPH,
@@ -136,7 +137,7 @@ export async function getRelatedSubjectsForWorshipAdministrativeUnit(
   pathToWorshipAdminUnit,
   destinationGraphs
 ) {
-  const graphsToExclude = `<${[...destinationGraphs, DISPATCH_SOURCE_GRAPH].join('>, <')}>`;
+  const graphsToExclude = `<${[...destinationGraphs, DISPATCH_SOURCE_GRAPH, ...LANDING_ZONE_GRAPHS.split(',')].join('>, <')}>`;
 
   let minusBlocks = '';
   for (const destinationGraph of destinationGraphs) {
@@ -179,30 +180,9 @@ export async function getRelatedSubjectsForWorshipAdministrativeUnit(
   return [...new Set(subjects)];
 }
 
-export async function copySubjectDataToDestinationGraphs(subject, destinationGraphs) {
-  let insertInGraphs = '';
-  for (const destinationGraph of destinationGraphs) {
-    insertInGraphs += `
-      GRAPH ${sparqlEscapeUri(destinationGraph)} {
-        ?s ?p ?o .
-      }
-    `;
-  }
-
-  // Insert in the destination graphs
-  const insertQueryStr = `
-    INSERT {
-      ${insertInGraphs}
-    }
-    WHERE {
-      BIND(${sparqlEscapeUri(subject)} as ?s)
-      ?s ?p ?o .
-    }
-  `;
-  await update(insertQueryStr);
-
-  // Delete triples in graphs that are not in the destination graphs list
-  const graphsToKeep = `<${[...destinationGraphs, DISPATCH_SOURCE_GRAPH].join('>, <')}>`;
+export async function moveSubjectDataToDestinationGraphs(subject, destinationGraphs) {
+  // Delete triples in all non-internal graphs (ingest graph and landing zones)
+  const graphsToKeep = `<${[DISPATCH_SOURCE_GRAPH, ...LANDING_ZONE_GRAPHS.split(',')].join('>, <')}>`;
 
   const deleteQueryStr = `
     DELETE {
@@ -219,6 +199,27 @@ export async function copySubjectDataToDestinationGraphs(subject, destinationGra
     }
   `;
   await update(deleteQueryStr);
+
+  // Insert in the destination graphs
+  let insertInGraphs = '';
+  for (const destinationGraph of destinationGraphs) {
+    insertInGraphs += `
+      GRAPH ${sparqlEscapeUri(destinationGraph)} {
+        ?s ?p ?o .
+      }
+    `;
+  }
+
+  const insertQueryStr = `
+    INSERT {
+      ${insertInGraphs}
+    }
+    WHERE {
+      BIND(${sparqlEscapeUri(subject)} as ?s)
+      ?s ?p ?o .
+    }
+  `;
+  await update(insertQueryStr);
 }
 
 export async function allInitialSyncsDone() {


### PR DESCRIPTION
In [this PR](https://github.com/lblod/app-worship-organizations/pull/22) we bump the consumers to a newer version, which has some consequences on how the dispatcher operates:
- Those new consumers are introducing new graphs, which are landing zones. In other words, graphs that are storing the consumed data without any modification. It serves as a base for the mapping etc that happens afterwards
- Previously, the consumers were deleting the received `DELETES` from ALL the graphs (including the org graphs) and then inserting to the ingest graph. Now, the consumers only have an effect on the landing zone and on the ingest graph, not on the organization graphs anymore

For those reasons, we have to adapt this service as follows:
- Ensure we don't touch the landing zones, they should be the reflect of the consumed data and stay untouched by other services
- Ensure we do delete old triples in this service, as the consumers don't handle it anymore. This is now done by `moveSubjectDataToDestinationGraphs` where we first delete all triples related to the subject of interest in the organization graphs and then re-insert the valid triples to the correct destination graphs.