### PR TITLE
Handle deltas containing only deletes

### DIFF
--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -1,10 +1,13 @@
-pipeline:
-  build:
-    image: plugins/docker
+steps:
+  build-and-push:
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       tags: latest
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  branch: master
-  event: push
+  - event: push
+    branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -1,10 +1,13 @@
-pipeline:
-  build:
-    image: plugins/docker
+steps:
+  release:
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       tags: "${CI_COMMIT_TAG##v}"
-    secrets: [ docker_username, docker_password ]
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
 when:
-  event: tag
-  tag: v*
+  - event: tag
+    ref: refs/tags/v*

--- a/.woodpecker/.test-build.yml
+++ b/.woodpecker/.test-build.yml
@@ -1,9 +1,8 @@
-pipeline:
-  build:
-    image: plugins/docker
+steps:
+  testbuild:
+    image: woodpeckerci/plugin-docker-buildx
     settings:
       repo: ${CI_REPO}
       dry_run: true
 when:
-  event:
-    - pull_request
+  - event: pull_request

--- a/app.js
+++ b/app.js
@@ -56,15 +56,9 @@ app.get("/", function (req, res) {
 app.post("/delta", async function (req, res) {
   const delta = new Delta(req.body);
 
-  if (!delta.inserts.length) {
-    console.log(
-      "Delta does not contain any insertions. Nothing should happen."
-    );
-    return res.status(204).send();
-  }
-
   const inserts = delta.inserts;
-  const subjects = inserts.map(insert => insert.subject.value);
+  const deletes = delta.deletes;
+  const subjects = [...inserts.map(insert => insert.subject.value), ...deletes.map(insert => insert.subject.value)];
   const uniqueSubjects = [ ...new Set(subjects) ];
 
   for (const subject of uniqueSubjects) {

--- a/lib/delta.js
+++ b/lib/delta.js
@@ -10,6 +10,10 @@ export class Delta {
     return flatten(this.delta.map((changeSet) => changeSet.inserts));
   }
 
+  get deletes() {
+    return flatten(this.delta.map((changeSet) => changeSet.deletes));
+  }
+
   getInsertsFor(trigger) {
     return this.inserts
       .filter((triple) => this.isTriggerTriple(triple, trigger))

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -128,8 +128,10 @@ export async function getDestinationGraphs(worshipAdministrativeUnit) {
 
 /**
  * Get the subjects which have some triples to move in org graphs
- * For this, we take all triples that are in a wrong graph (so that they get removed)
- * and all triples that are in the ingest graph but not yet in the destination graphs
+ * For this, we take:
+ * - all triples that are in a wrong graph (so that they get removed)
+ * - all triples that are in the ingest graph but not yet in the destination graphs (insert case)
+ * - all triples that are in an org graph but not anymore in the ingest graph (delete case)
  */
 export async function getRelatedSubjectsForWorshipAdministrativeUnit(
   worshipAdministrativeUnit,
@@ -139,9 +141,9 @@ export async function getRelatedSubjectsForWorshipAdministrativeUnit(
 ) {
   const graphsToExclude = `<${[...destinationGraphs, DISPATCH_SOURCE_GRAPH, ...LANDING_ZONE_GRAPHS.split(',')].join('>, <')}>`;
 
-  let minusBlocks = '';
+  let destinationGraphBlocks = '';
   for (const destinationGraph of destinationGraphs) {
-    minusBlocks += `
+    destinationGraphBlocks += `
       GRAPH ${sparqlEscapeUri(destinationGraph)} {
         ?subject ?p ?o .
       }
@@ -168,7 +170,19 @@ export async function getRelatedSubjectsForWorshipAdministrativeUnit(
         }
         MINUS
         {
-          ${minusBlocks}
+          ${destinationGraphBlocks}
+        }
+      }
+      UNION
+      {
+        {
+          ${destinationGraphBlocks}
+        }
+        MINUS
+        {
+          GRAPH ${sparqlEscapeUri(DISPATCH_SOURCE_GRAPH)} {
+            ?subject ?p ?o .
+          }
         }
       }
     }
@@ -215,8 +229,10 @@ export async function moveSubjectDataToDestinationGraphs(subject, destinationGra
       ${insertInGraphs}
     }
     WHERE {
-      BIND(${sparqlEscapeUri(subject)} as ?s)
-      ?s ?p ?o .
+      GRAPH ${sparqlEscapeUri(DISPATCH_SOURCE_GRAPH)} {
+        BIND(${sparqlEscapeUri(subject)} as ?s)
+        ?s ?p ?o .
+      }
     }
   `;
   await update(insertQueryStr);
@@ -302,10 +318,14 @@ export async function insertRepresentativeOrganExtraTriples(ro) {
     PREFIX org: <http://www.w3.org/ns/org#>
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
-    INSERT DATA {
+    INSERT {
       GRAPH ${sparqlEscapeUri(DISPATCH_SOURCE_GRAPH)} {
         ${sparqlEscapeUri(ro)} a besluit:Bestuurseenheid ;
           org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> .
+      }
+    } WHERE {
+      GRAPH ${sparqlEscapeUri(DISPATCH_SOURCE_GRAPH)} {
+        ${sparqlEscapeUri(ro)} a <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan> .
       }
     }
   `;


### PR DESCRIPTION
# Context

[OP-3589]

When using `worship-positions-graph-dispatcher-service` as a base for `contact-data-dispatcher-service` I found a bug: if we receive only deletes and no insert/update on a resource, the dispatching will not be triggered, causing some values to stay in the public/org graph(s) when it should actually be gone.

# How to reproduce the bug

On a local `app-worship-organizations` stack, first clone the dev database via:
```
rm -rf data/db
rsync -e ssh -avz -P root@abb-bfg.s.redpencil.io:/data/app-worship-organizations-dev/data/db ./data/
```

Then add the following to your docker-compose.override.yml:
```
  worship-services-sensitive-consumer:
    environment:
      DCR_SYNC_BASE_URL: "https://dev.loket.lblod.info"
      DCR_SYNC_LOGIN_ENDPOINT: "https://dev.loket.lblod.info/sync/worship-services-sensitive/login"
      DCR_SECRET_KEY: "not-going-to-commit-it" # Check the real key out or ask me in private :)
      DCR_LANDING_ZONE_DATABASE: "db"
      DCR_REMAPPING_DATABASE: "db"
      DCR_DISABLE_DELTA_INGEST: "false"
      DCR_DISABLE_INITIAL_SYNC: "false"
```
and fire up the stack:
```
drc up -d
```

Then take any position with a filled in secondary phone number in DEV Loket or create one and wait for it to sync locally. Then simply remove a secondary phone number from DEV Loket, without any other change. The result will be that the phone number will be deleted from the landing zone and from the ingest graph, but NOT from the organization graphs.

**Extra note:** not sure if it's a local issue, but the current image of `worship-services-sensitive-consumer` (v0.1.1) was not found by my docker-compose. I had to bump it to `image: lblod/delta-consumer:0.1.4`. I'll bump it in `app-worship-organizations` when bumping this service. 

# Test instructions

Basically the same as in the previous section, just checkout the PR and add the service's sources directly to the stack
```
  positions-dispatcher:
    environment:
      NODE_ENV: "development"
    volumes:
      - /path/to/worship-positions-graph-dispatcher-service/:/app/
```

The result should now be that it adds on `inserts`, deletes on `deletes` and update when both `inserts` and `deletes` are in the consumed delta.